### PR TITLE
大会予定ページの追加

### DIFF
--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -1,15 +1,23 @@
 class RacesController < ApplicationController
+  before_action :authenticate_user!
+
   def new
     @race = Race.new
   end
 
   def create
     @race = Race.new(race_params)
+    @race.user_id = current_user.id
     if @race.save
       redirect_to @race, notice: "Race was successfully created."
     else
       render :new
     end
+  end
+
+  def index
+    @races = current_user.races
+    puts @races.inspect
   end
 
   private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,5 @@
 class User < ApplicationRecord
-  # Include default devise modules. Others available are:
-  # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :races
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -10,4 +10,5 @@
 <body>
   <h2>RunChronicleはランナーのためのアプリです。</h2>
   <%= link_to '大会予定を登録する', new_race_path %>
+  <%= link_to '大会予定を確認する', races_path  %>
 </body>

--- a/app/views/races/index.html.erb
+++ b/app/views/races/index.html.erb
@@ -1,0 +1,9 @@
+<h1>大会予定</h1>
+
+<ul>
+  <% @races.each do |race| %>
+    <li><%= race.name %> - <%= race.date %></li>
+  <% end %>
+</ul>
+
+<%= link_to '戻る', home_index_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,17 +3,7 @@ Rails.application.routes.draw do
   get "home/index", to: "home#index", as: "home_index"
   root to: "home#index"
   resources :races
-  get "races/:id", to: "races#show"
-  # Define your application routes per the DSL in https://guides.rubyonrails.org/routing.html
-
-  # Reveal health status on /up that returns 200 if the app boots with no exceptions, otherwise 500.
-  # Can be used by load balancers and uptime monitors to verify that the app is live.
   get "up" => "rails/health#show", as: :rails_health_check
-
-  # Render dynamic PWA files from app/views/pwa/*
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
-
-  # Defines the root path route ("/")
-  # root "posts#index"
 end

--- a/db/migrate/20250104035546_add_user_id_to_races.rb
+++ b/db/migrate/20250104035546_add_user_id_to_races.rb
@@ -1,0 +1,5 @@
+class AddUserIdToRaces < ActiveRecord::Migration[7.2]
+  def change
+    add_column :races, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_02_084324) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_04_035546) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -26,6 +26,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_02_084324) do
     t.date "payment_due_date"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
   end
 
   create_table "users", force: :cascade do |t|


### PR DESCRIPTION
・ユーザーがログインした状態でトップページにアクセスすると大会予定を確認できる機能を実装。
・RacesテーブルにUser_idを追加しログインしたユーザーの大会予定のみを表示させられるようにしています。