### PR TITLE
Eventテーブル、RaceEventテーブルの作成

### DIFF
--- a/app/models/event.rb
+++ b/app/models/event.rb
@@ -1,0 +1,4 @@
+class Event < ApplicationRecord
+  has_many :race_events
+  has_many :races, through: :race_events
+end

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -1,3 +1,5 @@
 class Race < ApplicationRecord
   has_one :category
+  has_many :race_events
+  has_many :events, through: :race_events
 end

--- a/app/models/race_event.rb
+++ b/app/models/race_event.rb
@@ -1,0 +1,4 @@
+class RaceEvent < ApplicationRecord
+  belongs_to :race
+  belongs_to :event
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,5 +1,4 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
-  has_many :races
 end

--- a/db/migrate/20250421122438_create_events.rb
+++ b/db/migrate/20250421122438_create_events.rb
@@ -1,0 +1,10 @@
+class CreateEvents < ActiveRecord::Migration[7.2]
+  def change
+    create_table :events do |t|
+      t.string :event
+      t.float :distance
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250421122754_create_race_events.rb
+++ b/db/migrate/20250421122754_create_race_events.rb
@@ -1,0 +1,7 @@
+class CreateRaceEvents < ActiveRecord::Migration[7.2]
+  def change
+    create_table :race_events do |t|
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20250422105615_add_columns_to_race_event.rb
+++ b/db/migrate/20250422105615_add_columns_to_race_event.rb
@@ -1,0 +1,6 @@
+class AddColumnsToRaceEvent < ActiveRecord::Migration[7.2]
+  def change
+    add_reference :race_events, :race, null: false, foreign_key: true
+    add_reference :race_events, :event, null: false, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_01_04_035546) do
+ActiveRecord::Schema[7.2].define(version: 2025_04_22_105615) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -18,6 +18,22 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_04_035546) do
     t.string "name"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+  end
+
+  create_table "events", force: :cascade do |t|
+    t.string "event"
+    t.float "distance"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  create_table "race_events", force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "race_id", null: false
+    t.bigint "event_id", null: false
+    t.index ["event_id"], name: "index_race_events_on_event_id"
+    t.index ["race_id"], name: "index_race_events_on_race_id"
   end
 
   create_table "races", force: :cascade do |t|
@@ -40,4 +56,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_01_04_035546) do
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
+
+  add_foreign_key "race_events", "events"
+  add_foreign_key "race_events", "races"
 end

--- a/test/fixtures/events.yml
+++ b/test/fixtures/events.yml
@@ -1,0 +1,9 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+one:
+  event: MyString
+  distance: 1.5
+
+two:
+  event: MyString
+  distance: 1.5

--- a/test/fixtures/race_events.yml
+++ b/test/fixtures/race_events.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+# This model initially had no columns defined. If you add columns to the
+# model remove the "{}" from the fixture names and add the columns immediately
+# below each fixture, per the syntax in the comments below
+#
+one: {}
+# column: value
+#
+two: {}
+# column: value

--- a/test/models/event_test.rb
+++ b/test/models/event_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class EventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end

--- a/test/models/race_event_test.rb
+++ b/test/models/race_event_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class RaceEventTest < ActiveSupport::TestCase
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更の概要
マラソンやハーフマラソンなどの種目(Event)を登録するためのテーブルを追加しました。

## なぜこの変更をするのか
日時、大会名に加えて、出場する種目や距離の登録もできるアプリにしたいため。

## やったこと

*  [X] ER図の修正
*  [X] Eventテーブルの追加 
*  [X] RaceEventテーブルの追加

## 変更内容
【変更後のER図】

![Image](https://github.com/user-attachments/assets/e8f2a6a0-4a94-49a7-b25c-634b1b05bc89)

## 影響範囲
テーブルの追加以外に変化点はありません。

## どうやるのか
今回はDBスキーマのみの変更であり、画面やAPIへの影響はありません。

## 課題
次に予定しているFormObjectの実装要件がまだ整理しきれておらず、不安が残っています。

## 備考
特記事項はありません。
