### PR TITLE
Feature/add events

### DIFF
--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -2,16 +2,15 @@ class RacesController < ApplicationController
   before_action :authenticate_user!
 
   def new
-    @race = Race.new
+    @form = RaceForm.new
   end
 
   def create
-    @race = Race.new(race_params)
-    @race.user_id = current_user.id
-    if @race.save
-      redirect_to @race, notice: "Race was successfully created."
+    @form = RaceForm.new(race_params)
+    if @form.save
+      redirect_to races_path, notice: "Race was successfully created."
     else
-      render :new
+      render :new, status: :unprocessable_entity
     end
   end
 
@@ -23,6 +22,6 @@ class RacesController < ApplicationController
   private
 
   def race_params
-    params.require(:race).permit(:name, :date)
+    params.require(:race).permit(:name, :date, :event, :distance, :payment_due_date).merge(user_id: current_user.id)
   end
 end

--- a/app/forms/race_form.rb
+++ b/app/forms/race_form.rb
@@ -1,0 +1,50 @@
+class RaceForm
+  include ActiveModel::Model
+
+  attr_accessor :name, :date, :payment_due_date, :event, :distance, :user_id
+
+  validates :name, presence: true
+  validates :date, presence: true
+  validates :payment_due_date, presence: true
+  validates :event, presence: true
+  validates :distance, presence: true
+  validates :user_id, presence: true
+
+  delegate :persisted?, to: :race
+
+  def initialize(attributes = nil, race: Race.new)
+    @race = race
+    attributes ||= default_attributes
+    super(attributes)
+  end
+
+  def save
+    return if invalid?
+    ActiveRecord::Base.transaction do
+      race.update!(name: name, date: date, payment_due_date: payment_due_date, user_id: @user_id)
+      event_record = Event.find_or_create_by!(event: event, distance: distance)
+      race.events << event_record
+    end
+    rescue ActiveRecord::RecordInvalid => e
+    errors.add(:base, e.message)
+    false
+  end
+
+  def to_model
+    race
+  end
+
+  private
+
+  attr_reader :race
+
+  def default_attributes
+    {
+      name: race.name,
+      date: race.date,
+      payment_due_date: race.payment_due_date,
+      event: race.events.map(&:event).join(','),
+      distance: race.events.map(&:distance).join(',')
+    }
+  end
+end

--- a/app/forms/race_form.rb
+++ b/app/forms/race_form.rb
@@ -43,8 +43,8 @@ class RaceForm
       name: race.name,
       date: race.date,
       payment_due_date: race.payment_due_date,
-      event: race.events.map(&:event).join(','),
-      distance: race.events.map(&:distance).join(',')
+      event: race.events.map(&:event).join(","),
+      distance: race.events.map(&:distance).join(",")
     }
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
+  has_many :races
 end

--- a/app/views/races/_form.html.erb
+++ b/app/views/races/_form.html.erb
@@ -1,0 +1,13 @@
+<%= form_with model: form , local: true do |form| %>
+  <%= form.label '大会名'%>
+  <%= form.text_field :name,placeholder: '東京マラソン'  %>
+  <%= form.label '日程' %>
+  <%= form.text_area :date, placeholder: '2025-01-01' %>
+  <%= form.label '種目' %>
+  <%= form.text_field :event, placeholder: 'フルマラソン'  %>
+  <%= form.label '距離' %>
+  <%= form.text_field :distance, placeholder: '42.195'  %> <div>"km"</div>
+  <%= form.label '入金期限' %>
+  <%= form.text_area :payment_due_date, placeholder: '2025-01-01' %>
+  <%= form.submit '登録' %>
+<% end %>

--- a/app/views/races/index.html.erb
+++ b/app/views/races/index.html.erb
@@ -2,7 +2,14 @@
 
 <ul>
   <% @races.each do |race| %>
-    <li><%= race.name %> - <%= race.date %></li>
+    <h1><%= race.name %></h1>
+    <h1><%= race.date %></h1>
+    <h1><%= race.payment_due_date %></h1>
+  <% end %>
+
+  <% @races.event.each do |event| %>
+    <%= event.name %>
+    <%= event.distance %>
   <% end %>
 </ul>
 

--- a/app/views/races/index.html.erb
+++ b/app/views/races/index.html.erb
@@ -2,15 +2,15 @@
 
 <ul>
   <% @races.each do |race| %>
-    <h1><%= race.name %></h1>
-    <h1><%= race.date %></h1>
-    <h1><%= race.payment_due_date %></h1>
-  <% end %>
+ <p><strong>Name:</strong> <%= race.name %></p>
+ <p><strong>Date:</strong> <%= race.date %></p>
+ <p><strong>payment_due_date:</strong> <%= race.payment_due_date %></p>
 
-  <% @races.event.each do |event| %>
-    <%= event.name %>
-    <%= event.distance %>
+  <% race.events.each do |event| %>
+    <p><strong>event:</strong> <%= event.event %></p>
+    <p><strong>distance:</strong> <%= event.distance %>km</p>
   <% end %>
-</ul>
+<% end %>
+  </ul>
 
 <%= link_to '戻る', home_index_path %>

--- a/app/views/races/new.html.erb
+++ b/app/views/races/new.html.erb
@@ -1,18 +1,17 @@
-<h1>試合予定の登録</h2>
+<h1>試合予定の登録</h1>
 
-<%= form_with model: @race, local: true do |f| %>
-    <div class="field">
-      <%= f.label '大会名'%>
-      <%= f.text_field :name,  placeholder: '東京マラソン'  %>
-    </div>
+<%= render "form", form: @form %>
 
-    <div class="field">
-      <%= f.label '日程' %>
-      <%= f.text_field :date, placeholder: '2025-01-01' %>
-    </div>
+<% if @form.errors.any? %>
+  <div id="error_explanation">
+    <h2><%= pluralize(@form.errors.count, "error") %> prohibited this race from being saved:</h2>
 
-    <div class="actions">
-      <%= f.submit '登録' %>
-    </div>
-   <%= link_to '戻る', home_index_path %>
-  <% end %>
+    <ul>
+      <% @form.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+    </ul>
+  </div>
+<% end %>
+
+<%= link_to '戻る', home_index_path %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,7 +2,7 @@ Rails.application.routes.draw do
   devise_for :users
   get "home/index", to: "home#index", as: "home_index"
   root to: "home#index"
-  resources :races
+  resources :races, :events
   get "up" => "rails/health#show", as: :rails_health_check
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest


### PR DESCRIPTION
## 変更の概要
大会予定の登録フォームに種目・距離・入金期限欄を追加したしました。

* 変更の概要
* 関連するIssueやプルリクエスト

## なぜこの変更をするのか
「種目」「距離」「入金期限」を登録することで管理できる情報量を増やせるためです。

* 変更をする理由
* 前提知識がなくても分かるようにする

## やったこと

* [x] Event、Race_Eventテーブルの追加
* [x] 「種目」「距離」「入金期限」の登録フォームの追加
* [x] 大会予定ページへの反映 

## 変更内容
＜大会予定の登録画面＞
![Image](https://github.com/user-attachments/assets/040dc95a-300c-4b6f-8f83-462d93d7d0c3)
フォームに「種目」「距離」「入金期限」の入力欄を追加

＜大会予定画面＞

![Image](https://github.com/user-attachments/assets/5fb7b8ad-458e-45ec-98ba-f4a25d0ff1b1)
登録された情報が一覧画面にも表示されるように対応

## 影響範囲
- ユーザーへの影響：「種目」「距離」「入金期限」の情報を登録することができるようになります。
- 新規登録時の入力項目が増えるめ、ユーザーが入力すべき情報量が増える（利便性向上）
- 既存の登録データには影響なし（互換性あり）

## どうやるのか

使い方：フォームへの登録内容の入力


## 課題
特にありません。

## 備考
特にありません。

