### PR TITLE
大会予定の削除機能実装

### DIFF
--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -35,5 +35,4 @@ class RacesController < ApplicationController
   def race_params
     params.require(:race).permit(:name, :date, :event, :distance, :payment_due_date).merge(user_id: current_user.id)
   end
-
 end

--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -19,9 +19,21 @@ class RacesController < ApplicationController
     puts @races.inspect
   end
 
+  def show
+    @race = Race.find(params[:id])
+    @events = @race.events
+  end
+
+  def destroy
+    race = Race.find(params[:id])
+    race.destroy
+    redirect_to races_path, notice: "大会予定を削除しました・"
+  end
+
   private
 
   def race_params
     params.require(:race).permit(:name, :date, :event, :distance, :payment_due_date).merge(user_id: current_user.id)
   end
+
 end

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -1,5 +1,5 @@
 class Race < ApplicationRecord
   has_one :category
-  has_many :race_events
+  has_many :race_events,dependent: :destroy
   has_many :events, through: :race_events
 end

--- a/app/models/race.rb
+++ b/app/models/race.rb
@@ -1,5 +1,5 @@
 class Race < ApplicationRecord
   has_one :category
-  has_many :race_events,dependent: :destroy
+  has_many :race_events, dependent: :destroy
   has_many :events, through: :race_events
 end

--- a/app/views/races/index.html.erb
+++ b/app/views/races/index.html.erb
@@ -2,15 +2,14 @@
 
 <ul>
   <% @races.each do |race| %>
- <p><strong>Name:</strong> <%= race.name %></p>
- <p><strong>Date:</strong> <%= race.date %></p>
- <p><strong>payment_due_date:</strong> <%= race.payment_due_date %></p>
+ <p><strong>大会名:</strong> <%= link_to race.name, race_path(race) %></p>
+ <p><strong>日付:</strong> <%= race.date %></p>
+ <p><strong>入金期限:</strong> <%= race.payment_due_date %></p>
 
   <% race.events.each do |event| %>
-    <p><strong>event:</strong> <%= event.event %></p>
-    <p><strong>distance:</strong> <%= event.distance %>km</p>
+    <p><strong>種目:</strong> <%= event.event %></p>
+    <p><strong>距離:</strong> <%= event.distance %>km</p>
   <% end %>
 <% end %>
   </ul>
-
 <%= link_to '戻る', home_index_path %>

--- a/app/views/races/show.html.erb
+++ b/app/views/races/show.html.erb
@@ -1,0 +1,31 @@
+<div>
+  <p>
+    <strong>大会名:</strong>
+    <%= @race.name %>
+  </p>
+
+  <p>
+    <strong>日付:</strong>
+    <%= @race.date %>
+  </p>
+
+  <p>
+    <strong>入金期限:</strong>
+    <%= @race.payment_due_date %>
+  </p>
+
+  <% @events.each do |event| %>
+  <p>
+    <strong>種目:</strong>
+    <%= event.event %>
+  </p>
+
+  <p>
+    <strong>距離:</strong>
+    <%= event.distance %>km
+  </p>
+  <% end %>
+</p>
+</div>
+<%= button_to '削除', race_path(@race), method: :delete, data: { confirm: '本当に削除しますか？' } %>
+<%= link_to '戻る', home_index_path %>


### PR DESCRIPTION
## 変更の概要

・/races/:id にGETリクエストを送ることで、個別の大会予定を確認できるようにしました
・同画面から該当予定を削除できるようにしました（DELETE /races/:id）

## なぜこの変更をするのか

・ユーザーが大会出場を取りやめるケース（体調不良、日程都合など）を想定
・誤って登録した場合のキャンセル手段としても必要


## やったこと

* [x] `RacesController#show` アクションの実装（大会予定の詳細表示）
* [x] `RacesController#destroy` アクションの実装（大会予定の削除）
* [x] `views/races/show.html.erb` の作成（表示＋削除ボタンの追加）　 

## 変更内容

・詳細ページの表示画面（大会名・種目・距離などを確認可能）
![image](https://github.com/user-attachments/assets/9f1ea729-dbbb-4d92-aa7e-92164688f94c)



## 影響範囲

### ユーザーへの影響
- 大会予定の個別ページ閲覧、削除が可能に

### システム・他メンバーへの影響
- 新規ページ／アクションの追加のみ。既存機能への影響なし。

## どうやるのか
レース一覧ページの大会名をクリックすることで閲覧可能
![image](https://github.com/user-attachments/assets/f9727854-6b2b-44fc-8071-915b8687f69d)

## 課題
特になし

## 備考
特になし
