### PR TITLE
ログイン必須に修正

### DIFF
--- a/app/controllers/race_results_controller.rb
+++ b/app/controllers/race_results_controller.rb
@@ -1,4 +1,6 @@
 class RaceResultsController < ApplicationController
+  before_action :is_marching_login_user, only: %i[show edit destroy]
+
   def new
     @race = Race.find(params[:race_id])
     @race_result = RaceResult.new()
@@ -8,7 +10,7 @@ class RaceResultsController < ApplicationController
   def create
     @race = Race.find(params[:race_id])
     @race_result = RaceResult.new(race_result_params)
-    @events = @race.events
+    @events = @race.event
     if  @race_result.save
         redirect_to race_result_params, notice: "Race was successfully created."
     else
@@ -35,5 +37,12 @@ class RaceResultsController < ApplicationController
   def race_result_params
     params.require(:race_result).permit(:record_time_in_seconds, :impression)
           .merge(user_id: current_user.id, race_id: params[:race_id])
+  end
+
+  def is_marching_login_user
+    race = Race.find(params[:race_id])
+    unless race.user_id == current_user.id
+      redirect_to races_path
+    end
   end
 end

--- a/app/controllers/races_controller.rb
+++ b/app/controllers/races_controller.rb
@@ -1,6 +1,7 @@
 class RacesController < ApplicationController
   before_action :authenticate_user!
   before_action :set_race, only: %i[edit update]
+  before_action :is_marching_login_user, only: %i[show edit destroy]
 
   def new
     @form = RaceForm.new
@@ -32,7 +33,6 @@ class RacesController < ApplicationController
 
   def edit
     @race = RaceForm.new(race: @race)
-    Rails.logger.debug "🔥#{@race}"
   end
 
   def update
@@ -52,5 +52,13 @@ class RacesController < ApplicationController
 
   def set_race
     @race = Race.find(params[:id])
+  end
+
+private
+  def is_marching_login_user
+    race = Race.find(params[:id])
+    unless race.user_id == current_user.id
+      redirect_to races_path
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,4 @@ Rails.application.routes.draw do
   get "service-worker" => "rails/pwa#service_worker", as: :pwa_service_worker
   get "manifest" => "rails/pwa#manifest", as: :pwa_manifest
   post "/races/:id/edit", to: "races#update"
-  post "/races/:id/race_result/new", to: "race_results#create"
-  get "/races/:race_id/race_result/:race_result_id", to:  "race_results#show"
 end


### PR DESCRIPTION
背景

ポートフォリオアプリの開発中、ユーザー個人のみに閲覧・編集権限があるべきページに対して、URLを直接指定することで他ユーザーがアクセス・操作できてしまう認可漏れ（アクセス制御の不備）に気づいた。

対応

https://zenn.dev/goldsaya/articles/e8888db80fb060
上記の記事を参照することで、事前にログイン中のユーザーIDと対象としている投稿のURLを照合しておくことで、他ユーザーのアクセスが防げることがわかった。

実装過程

①記事の内容を参考にユーザー照合のメソッドを設置した

```ruby
private
  def is_marching_login_user
    user = Race.find_by(params[:user_id])
    unless user.id == current_user.id
      redirect_to races_path
    end
  end
```

この実装で一部のアクションでは他ユーザーのアクセスが防げるが、

editアクションにアクセスができなかった。

AIにデバッグの方法を確認し、以下のログが確認できた。

```ruby
web-1  | 17:13:17 web.1  | Processing by RacesController#edit as HTML
web-1  | 17:13:17 web.1  |   Parameters: {"id"=>"34"}
web-1  | 17:13:17 web.1  |   User Load (0.6ms)  SELECT "users".* FROM "users" WHERE "users"."id" = $1 ORDER BY "users"."id" ASC LIMIT $2  [["id", 2], ["LIMIT", 1]]
web-1  | 17:13:18 web.1  |   Race Load (0.2ms)  SELECT "races".* FROM "races" WHERE "races"."id" = $1 LIMIT $2  [["id", 34], ["LIMIT", 1]]
web-1  | 17:13:18 web.1  |   ↳ app/controllers/races_controller.rb:55:in `set_race'
web-1  | 17:13:18 web.1  |   Race Load (0.3ms)  SELECT "races".* FROM "races" LIMIT $1  [["LIMIT", 1]]
web-1  | 17:13:18 web.1  |   ↳ app/controllers/races_controller.rb:60:in `is_marching_login_user'
web-1  | 17:13:18 web.1  | 🔍 user: #<Race id: 28, name: "大阪マラソン", date: "2025-04-01", payment_due_date: "2025-03-01", created_at: "2025-05-14 10:37:55.315778000 +0000", updated_at: "2025-05-14 10:37:55.315778000 +0000", user_id: 1>
web-1  | 17:13:18 web.1  | 🔍 current_user: #<User id: 2, email: [FILTERED], created_at: "2025-05-25 06:03:00.822778000 +0000", updated_at: "2025-05-25 06:03:00.822778000 +0000">
web-1  | 17:13:18 web.1  | ❌ user.id (28) does not match current_user.id (2)
```

本来、Race_idの34に含まれるuser_idとログイン中のuser_idを比較すべきところ、

Race_id:28との比較を行っていた。

→ここで、Race.find_by(params[:user_id])ではRaceテーブルのすべてのデータが対象となってしまうことに気付く。また、find_byの引数としてuser_idを渡しているが、これが有効ではないことには気づいていなかった。

```ruby
user = Race.find_by(params[:id,:user_id])
```

```ruby
user = Race(params[:id]).find_by(params[:user_id])
```

など、表記を変えuser_idをURLのidとして指定しようとするが、エラーとなっていた。

```ruby
private
  def is_marching_login_user
    race = Race.find(params[:id])
    unless race.user_id == current_user.id
      redirect_to races_path
    end
  end
```

最終的には上記のコードで無事、他ユーザーからのアクセスを制限する機能が実現できた。

勘違いしていたポイント

①find_byの引数で検索対象のカラムを指示する必要があると思っていたこと

→実際はunlessでカラムを指示しているので、find_byで対象のカラム指定は必要なし。

理解したこと
SQLの発行はRace.find(params[:id])で行われており、race.user_idは取得したデータの読み取りを行っている。