### PR TITLE
Feature/add user profile fields

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,5 +6,8 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     added_attrs = [ :name, :email, :password, :password_confirmation ]
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
+    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
+    devise_parameter_sanitizer.permit(:sign_in, keys: [:email])
+    devise_parameter_sanitizer.permit(:sign_in, keys: [:password])
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,4 +1,10 @@
 class ApplicationController < ActionController::Base
-  # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
+  before_action :configure_permitted_parameters, if: :devise_controller?
   allow_browser versions: :modern
+
+  private
+  def configure_permitted_parameters
+    added_attrs = [ :name, :email, :password, :password_confirmation ]
+    devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
+  end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -6,8 +6,8 @@ class ApplicationController < ActionController::Base
   def configure_permitted_parameters
     added_attrs = [ :name, :email, :password, :password_confirmation ]
     devise_parameter_sanitizer.permit :sign_up, keys: added_attrs
-    devise_parameter_sanitizer.permit(:account_update, keys: [:name])
-    devise_parameter_sanitizer.permit(:sign_in, keys: [:email])
-    devise_parameter_sanitizer.permit(:sign_in, keys: [:password])
+    devise_parameter_sanitizer.permit(:account_update, keys: [ :name ])
+    devise_parameter_sanitizer.permit(:sign_in, keys: [ :email ])
+    devise_parameter_sanitizer.permit(:sign_in, keys: [ :password ])
   end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,62 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  # def new
+  #   super
+  # end
+
+  # POST /resource
+  # def create
+  #   super
+  # end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_up_params
+  #   devise_parameter_sanitizer.permit(:sign_up, keys: [:attribute])
+  # end
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_account_update_params
+  #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+  # end
+
+  # The path used after sign up.
+  # def after_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sign up for inactive accounts.
+  # def after_inactive_sign_up_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,0 +1,7 @@
+class UsersController < ApplicationController
+
+  def show
+    @user = User.find(current_user[:id])
+  end
+
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,7 +1,5 @@
 class UsersController < ApplicationController
-
   def show
     @user = User.find(current_user[:id])
   end
-
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,0 +1,2 @@
+module UsersHelper
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -3,4 +3,5 @@ class User < ApplicationRecord
          :recoverable, :rememberable, :validatable
   has_many :races, dependent: :destroy
   has_many :race_result_comments, dependent: :destroy
+  validates :name, uniqueness: true, presence: true
 end

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -4,6 +4,7 @@
 
 <header>
   <h1>RunChronicle</h1>
+  <%= link_to 'プロフィール', user_path(current_user) %>
   <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete } %>
 </header>
 

--- a/app/views/users/registrations/new.html.erb
+++ b/app/views/users/registrations/new.html.erb
@@ -4,6 +4,11 @@
   <%= render "users/shared/error_messages", resource: resource %>
 
   <div class="field">
+  <%= f.label :name %><br />
+  <%= f.text_field :name, autofocus: true, autocomplete: "name" %>
+  </div>
+
+  <div class="field">
     <%= f.label :email %><br />
     <%= f.email_field :email, autofocus: true, autocomplete: "email" %>
   </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,0 +1,5 @@
+<div>
+<%= @user.name %>
+
+<%= @user.profile %>
+</div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,5 +1,8 @@
-<div>
-<%= @user.name %>
+<head>プロフィール</head>
 
-<%= @user.profile %>
+<div>
+<p><strong>ユーザー名：</strong><%= @user.name %> </p>
+<p><strong>プロフィール：</strong><%= @user.profile %></p>
 </div>
+
+<%= link_to '戻る', home_index_path %>

--- a/compose.yml
+++ b/compose.yml
@@ -6,7 +6,7 @@ services:
       TZ: Asia/Tokyo
       POSTGRES_PASSWORD: password
     volumes:
-      - postgresql_data:/var/lib/postgresql
+      - postgresql_data:/var/lib/postgresql/data
     ports:
       - 5432:5432
     healthcheck:

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  config.authentication_keys = [:name]
+  # config.authentication_keys = [:name]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -46,7 +46,7 @@ Devise.setup do |config|
   # session. If you need permissions, you should implement that in a before filter.
   # You can also supply a hash where the value is a boolean determining whether
   # or not authentication should be aborted when the value is not present.
-  # config.authentication_keys = [:email]
+  config.authentication_keys = [:name]
 
   # Configure parameters from the request object used for authentication. Each entry
   # given should be a request method and it will automatically be passed to the

--- a/config/locales/devise.ja.yml
+++ b/config/locales/devise.ja.yml
@@ -25,6 +25,7 @@ ja:
         unconfirmed_email: 未確認Eメール
         unlock_token: ロック解除用トークン
         updated_at: 更新日
+        name: 名前
     models:
       user: ユーザー
   devise:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
+  resources :users, only: [:show, :index, :edit, :update]
   get "home/index", to: "home#index", as: "home_index"
   root to: "home#index"
   resources :events

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :users, only: [:show, :index, :edit, :update]
+  resources :users, only: [:show, :index, :edit, :update], path: 'users'
   get "home/index", to: "home#index", as: "home_index"
   root to: "home#index"
   resources :events

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,6 +1,6 @@
 Rails.application.routes.draw do
   devise_for :users
-  resources :users, only: [:show, :index, :edit, :update], path: 'users'
+  resources :users, only: [ :show, :index, :edit, :update ], path: "users"
   get "home/index", to: "home#index", as: "home_index"
   root to: "home#index"
   resources :events

--- a/db/migrate/20250603094901_add_profile_to_users.rb
+++ b/db/migrate/20250603094901_add_profile_to_users.rb
@@ -1,0 +1,5 @@
+class AddProfileToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :profile, :text
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2025_06_02_100948) do
+ActiveRecord::Schema[7.2].define(version: 2025_06_03_094901) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -78,6 +78,7 @@ ActiveRecord::Schema[7.2].define(version: 2025_06_02_100948) do
     t.text "bio"
     t.string "role"
     t.string "gender"
+    t.text "profile"
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -1,0 +1,7 @@
+require "test_helper"
+
+class UsersControllerTest < ActionDispatch::IntegrationTest
+  # test "the truth" do
+  #   assert true
+  # end
+end


### PR DESCRIPTION
## 変更の概要
・usersテーブルへの[:mame,profile_image,bio,role,gender]の追加
・プロフィールページの追加
→/users/:idでプロフィールページへアクセス
・Sing up時に名前を登録

関連Issue  https://github.com/Taunosuke/RunChronicle_2/issues/36

## なぜこの変更をするのか
各ユーザーの大会結果を他ユーザーが見られるようになる、「みんなの大会結果」ページの実装にあたり、
どのユーザーの大会結果なのかを識別できるようにする必要があるため。
また、プロフィールページを作成することで、他ユーザーの情報を得られるため、交流の促進につながる。

## やったこと

* [x] Userテーブルの修正
* [x] プロフィールページの追加
* [x] sing up時に名前登録の追加

## 変更内容
【プロフィールページへのリンク】
![image](https://github.com/user-attachments/assets/af0cac93-0cbb-41fb-85bf-27fd526c237b)

【プロフィールページ】
![image](https://github.com/user-attachments/assets/ee92fe7d-2eec-417e-9770-b3728c81c90e)

【会員登録ページ】
![image](https://github.com/user-attachments/assets/f859897b-ebb7-4592-a524-8d40882dc65b)

【ER図】
![image](https://github.com/user-attachments/assets/a206c34d-dff3-4dfa-9f36-b3099c65619e)
## 影響範囲
* ユーザーに影響すること
→会員登録時に名前登録が必須になりました。
プロフィールページで自分のプロフィールが確認可能になりました。

* メンバーに影響すること
* システムに影響すること
→Userテーブルのカラム構成が変更となっています。

## どうやるのか
名前の登録：sing upページの名前フォームに登録したい名前を記入する
プロフィール画面：トップページのプロフィールリンクから確認可能

## 課題
特になし

## 備考
次の実装として、プロフィールページの名前の編集機能を検討しています。
