### PR TITLE
CSSデザイン割り当て

### DIFF
--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,18 +1,67 @@
-<head>
-  <title>RunChronicle</title>
-</head>
+<!-- app/views/pages/home.html.erb など -->
 
-<header>
-  <h1>RunChronicle</h1>
-  <%= link_to 'プロフィール', user_path(current_user) %>
-  <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete } %>
-</header>
+  <!-- Main -->
+  <main class="mx-auto max-w-5xl px-4 py-10">
+    <!-- Hero -->
+    <section class="rounded-2xl bg-white shadow-sm border border-slate-200 p-6 md:p-8">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+        <!-- 左：アイキャッチ -->
+        <div class="flex items-center gap-4">
+          <div class="h-16 w-16 rounded-xl bg-gradient-to-br from-blue-500 to-emerald-500 flex items-center justify-center">
+            <!-- ランナーっぽい抽象アイコン（Heroicons placeholder） -->
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-9 w-9 text-white" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5" d="M13 7a2 2 0 11-4 0 2 2 0 014 0zM4 21l4-8 4 3 3-6 5 2"/>
+            </svg>
+          </div>
+          <p class="text-2xl md:text-3xl font-bold text-slate-900">
+            RunChronicleはランナーのためのアプリです。
+          </p>
+        </div>
+      </div>
 
-<body>
-  <h2>RunChronicleはランナーのためのアプリです。</h2>
-  <%= link_to '大会予定を登録する', new_race_path %>
-  <%= link_to '大会予定を確認する', races_path  %>
-  <%= link_to 'みんなの大会予定' , discover_races_path %>
-  <%= link_to '持ち物を登録する', new_item_path %>
-  <%= link_to '持ち物一覧', items_path %>
+      <!-- アクションカード -->
+      <div class="mt-8 grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4">
+        <%= link_to new_race_path, class: "group rounded-xl bg-white border border-slate-200 shadow-sm p-5 flex items-center gap-4 hover:shadow-md hover:border-blue-300 transition" do %>
+          <span class="h-11 w-11 rounded-lg bg-blue-50 text-blue-600 grid place-items-center">
+            <!-- カレンダー -->
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" viewBox="0 0 24 24" fill="currentColor"><path d="M7 2a1 1 0 011 1v1h8V3a1 1 0 112 0v1h1a2 2 0 012 2v12a2 2 0 01-2 2H4a2 2 0 01-2-2V6a2 2 0 012-2h1V3a1 1 0 112 0v1zm13 7H4v9a1 1 0 001 1h14a1 1 0 001-1V9z"/></svg>
+          </span>
+          <span class="font-semibold text-slate-900">大会予定を登録する</span>
+        <% end %>
+
+        <%= link_to races_path, class: "group rounded-xl bg-white border border-slate-200 shadow-sm p-5 flex items-center gap-4 hover:shadow-md hover:border-blue-300 transition" do %>
+          <span class="h-11 w-11 rounded-lg bg-emerald-50 text-emerald-600 grid place-items-center">
+            <!-- 予定確認 -->
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M9 12l2 2 4-4 1.5 1.5L11 17 7.5 13.5 9 12z"/></svg>
+          </span>
+          <span class="font-semibold text-slate-900">大会予定を確認する</span>
+        <% end %>
+
+        <%= link_to discover_races_path, class: "group rounded-xl bg-white border border-slate-200 shadow-sm p-5 flex items-center gap-4 hover:shadow-md hover:border-blue-300 transition" do %>
+          <span class="h-11 w-11 rounded-lg bg-blue-50 text-blue-600 grid place-items-center">
+            <!-- みんなの予定 -->
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M12 12a5 5 0 100-10 5 5 0 000 10zm-7 9a7 7 0 0114 0H5z"/></svg>
+          </span>
+          <span class="font-semibold text-slate-900">みんなの大会予定</span>
+        <% end %>
+
+        <%= link_to new_item_path, class: "group rounded-xl bg-white border border-slate-200 shadow-sm p-5 flex items-center gap-4 hover:shadow-md hover:border-emerald-300 transition" do %>
+          <span class="h-11 w-11 rounded-lg bg-emerald-50 text-emerald-600 grid place-items-center">
+            <!-- バッグ -->
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M8 7V6a4 4 0 118 0v1h3a1 1 0 011 1v11a2 2 0 01-2 2H6a2 2 0 01-2-2V8a1 1 0 011-1h3zm2-1a2 2 0 104 0v1h-4V6z"/></svg>
+          </span>
+          <span class="font-semibold text-slate-900">持ち物を登録する</span>
+        <% end %>
+
+        <%= link_to items_path, class: "group rounded-xl bg-white border border-slate-200 shadow-sm p-5 flex items-center gap-4 hover:shadow-md hover:border-emerald-300 transition" do %>
+          <span class="h-11 w-11 rounded-lg bg-emerald-50 text-emerald-600 grid place-items-center">
+            <!-- リスト -->
+            <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6" fill="currentColor" viewBox="0 0 24 24"><path d="M7 7h14v2H7V7zm0 5h14v2H7v-2zm0 5h14v2H7v-2zM3 7h2v2H3V7zm0 5h2v2H3v-2zm0 5h2v2H3v-2z"/></svg>
+          </span>
+          <span class="font-semibold text-slate-900">持ち物一覧</span>
+        <% end %>
+      </div>
+    </section>
+  </main>
 </body>
+

--- a/app/views/items/edit.html.erb
+++ b/app/views/items/edit.html.erb
@@ -1,5 +1,17 @@
-<%= form_with model: @item, local: true do |item| %>
-  <%= item.label 'アイテム名' %>
-  <%= item.text_field :name %>
-  <%= item.submit "登録する", class: "btn btn-primary" %>
-<% end %>
+<div class="max-w-md mx-auto mt-8 bg-white p-6 rounded-lg shadow">
+  <h1 class="text-xl font-bold text-slate-900 mb-4">アイテム登録</h1>
+
+  <%= form_with model: @item, local: true, class: "space-y-4" do |f| %>
+    <div>
+      <%= f.label :name, "アイテム名", class: "block text-sm font-medium text-slate-700 mb-1" %>
+      <%= f.text_field :name,
+            class: "w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring focus:ring-blue-200",
+            placeholder: "例: ランニングシューズ" %>
+    </div>
+
+    <div>
+      <%= f.submit "登録する",
+            class: "w-full inline-flex items-center justify-center rounded-lg bg-blue-600 px-4 py-2 text-white font-semibold shadow hover:bg-blue-700 transition" %>
+    </div>
+  <% end %>
+</div>

--- a/app/views/items/index.html.erb
+++ b/app/views/items/index.html.erb
@@ -1,10 +1,26 @@
-<h1>持ち物一覧</h1>
-<ul>
-  <% @items.each do |item| %>
-    <li>
-      <strong>持ち物名:</strong> <%= item.name %></p>
-    </li>
-         <%= link_to '編集', edit_item_path(item) %>
-      <%= link_to '削除', item_path(item), data: { turbo_method: :delete, confirm: '本当に削除しますか？' } %>
-  <% end %>
-<%= link_to '戻る', home_index_path %>
+<div class="max-w-2xl mx-auto mt-8 bg-white p-6 rounded-lg shadow">
+  <h1 class="text-2xl font-bold text-slate-900 mb-6">持ち物一覧</h1>
+
+  <ul class="divide-y divide-slate-200">
+    <% @items.each do |item| %>
+      <li class="flex justify-between items-center py-3">
+        <span class="text-slate-800 font-medium"><%= item.name %></span>
+        <div class="space-x-2">
+          <%= link_to '編集',
+                edit_item_path(item),
+                class: "px-3 py-1 bg-blue-500 text-white rounded hover:bg-blue-600 text-sm" %>
+          <%= link_to '削除',
+                item_path(item),
+                data: { turbo_method: :delete, confirm: '本当に削除しますか？' },
+                class: "px-3 py-1 bg-red-500 text-white rounded hover:bg-red-600 text-sm" %>
+        </div>
+      </li>
+    <% end %>
+  </ul>
+
+  <div class="mt-6">
+    <%= link_to '戻る',
+          home_index_path,
+          class: "inline-block px-4 py-2 bg-gray-200 rounded hover:bg-gray-300" %>
+  </div>
+</div>

--- a/app/views/items/new.html.erb
+++ b/app/views/items/new.html.erb
@@ -1,12 +1,17 @@
-<%= form_with model: @item, url: items_path, local: true,  data: { turbo: false } do |f| %>
-    <div class="form-group">
-        <%= f.label :name, "持ち物名" %>
-        <%= f.text_field :name, class: "form-control", placeholder: "持ち物名を入力してください" %>
+<div class="max-w-md mx-auto mt-8 bg-white p-6 rounded-lg shadow">
+  <%= form_with model: @item, url: items_path, local: true, data: { turbo: false } do |f| %>
+    <div class="mb-4">
+      <%= f.label :name, "持ち物名", class: "block text-sm font-medium text-slate-700 mb-1" %>
+      <%= f.text_field :name,
+            class: "w-full border border-slate-300 rounded-lg px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500",
+            placeholder: "持ち物名を入力してください" %>
     </div>
 
-    <div class="form-group">
-        <%= f.submit "登録する", class: "btn btn-primary" %>
+    <div class="flex space-x-3">
+      <%= f.submit "登録する",
+            class: "px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600" %>
+      <%= link_to "戻る", :back,
+            class: "px-4 py-2 bg-gray-200 text-slate-800 rounded hover:bg-gray-300" %>
     </div>
-<% end %>
-
-<%= link_to "戻る", :back %>
+  <% end %>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,8 +1,7 @@
-
 <!DOCTYPE html>
 <html>
   <head>
-    <title><%= content_for(:title) || "Myapp" %></title>
+    <title><%= content_for(:title) || "RunChronicle" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
@@ -14,11 +13,47 @@
     <link rel="icon" href="/icon.png" type="image/png">
     <link rel="icon" href="/icon.svg" type="image/svg+xml">
     <link rel="apple-touch-icon" href="/icon.png">
+
     <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
     <%= javascript_include_tag "application", "data-turbo-track": "reload", type: "module" %>
   </head>
 
-  <body>
-    <%= yield %>
+  <body class="bg-slate-50 text-slate-900">
+    <!-- 共通ヘッダー -->
+    <header class="sticky top-0 z-10 bg-white/90 backdrop-blur border-b border-slate-200">
+      <div class="mx-auto max-w-5xl px-4 h-14 flex items-center justify-between">
+        <h1 class="text-xl font-semibold text-blue-700">
+            <%= link_to "RunChronicle", root_path, class: "hover:text-blue-900 transition" %>
+        </h1>
+        <nav class="flex items-center gap-6 text-sm">
+          <% if defined?(user_signed_in?) && user_signed_in? %>
+            <%= link_to 'プロフィール', user_path(current_user), class: "text-slate-700 hover:text-blue-700 transition" %>
+            <%= link_to 'ログアウト', destroy_user_session_path, data: { turbo_method: :delete }, class: "text-slate-700 hover:text-blue-700 transition" %>
+          <% else %>
+            <%= link_to 'ログイン', new_user_session_path, class: "text-slate-700 hover:text-blue-700 transition" %>
+          <% end %>
+        </nav>
+      </div>
+    </header>
+
+    <!-- フラッシュ -->
+    <div class="mx-auto max-w-5xl px-4 mt-4 space-y-2">
+      <% flash.each do |type, msg| %>
+        <div class="rounded-lg border p-3 text-sm
+                    <%= type.to_s == 'notice' ? 'bg-emerald-50 border-emerald-200 text-emerald-800' : 'bg-red-50 border-red-200 text-red-800' %>">
+          <%= msg %>
+        </div>
+      <% end %>
+    </div>
+
+    <!-- 各ページ -->
+    <main class="mx-auto max-w-5xl px-4 py-10">
+      <%= yield %>
+    </main>
+
+    <!-- 共通フッター -->
+    <footer class="text-center text-sm text-slate-500 mt-8 mb-8">
+      © <%= Time.current.year %> RunChronicle
+    </footer>
   </body>
 </html>

--- a/app/views/race_results/_form.html.erb
+++ b/app/views/race_results/_form.html.erb
@@ -1,7 +1,26 @@
-<%= form_with model: @race_result ,url: race_race_result_path(@race), local: true do |form| %>
-    <%= form.label 'タイム'%>
-    <%= form.text_field :record_time_in_seconds %>
-    <%= form.label '感想' %>
-    <%= form.text_area :impression %>
-    <%= form.submit '登録' %>
-  <% end %>
+<%= form_with model: race_result, url: race_race_result_path(race), local: true,
+      class: "space-y-6 bg-white p-6 rounded-xl shadow-sm border border-slate-200" do |f| %>
+
+  <!-- タイム（秒） -->
+  <div>
+    <%= f.label :record_time_in_seconds, "タイム（秒）", class: "block text-sm font-medium text-slate-700 mb-1" %>
+    <%= f.number_field :record_time_in_seconds,
+          placeholder: "例: 12540（3時間29分）",
+          class: "w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring focus:ring-blue-200" %>
+    <p class="mt-1 text-xs text-slate-500">※タイムは秒単位で入力してください</p>
+  </div>
+
+  <!-- 感想 -->
+  <div>
+    <%= f.label :impression, "感想", class: "block text-sm font-medium text-slate-700 mb-1" %>
+    <%= f.text_area :impression, rows: 4,
+          placeholder: "大会を終えて感じたことやメモ",
+          class: "w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring focus:ring-blue-200" %>
+  </div>
+
+  <div>
+    <%= f.submit "登録",
+          class: "w-full rounded-lg bg-blue-600 px-4 py-2 text-white font-semibold shadow hover:bg-blue-700 transition" %>
+  </div>
+<% end %>
+

--- a/app/views/race_results/new.html.erb
+++ b/app/views/race_results/new.html.erb
@@ -1,31 +1,37 @@
-<h1>試合結果の登録</h1>
+<div class="mx-auto max-w-5xl px-4 py-8">
+  <h1 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">試合結果の登録</h1>
 
-<div>
-  <p>
-    <strong>大会名:</strong>
-    <%= @race.name %>
-  </p>
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+    <!-- 大会サマリー -->
+    <section class="lg:col-span-1 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 class="text-lg font-semibold text-slate-900 mb-4"><%= @race.name %></h2>
+      <dl class="space-y-2 text-sm">
+        <div class="grid grid-cols-3 gap-3">
+          <dt class="text-slate-500">日付</dt>
+          <dd class="col-span-2 text-slate-800"><%= @race.date&.strftime("%Y/%m/%d") || "—" %></dd>
+        </div>
+        <div class="grid grid-cols-3 gap-3">
+          <dt class="text-slate-500">入金期限</dt>
+          <dd class="col-span-2 text-slate-800"><%= @race.payment_due_date&.strftime("%Y/%m/%d") || "—" %></dd>
+        </div>
+        <div class="grid grid-cols-3 gap-3">
+          <dt class="text-slate-500">種目</dt>
+          <dd class="col-span-2 text-slate-800"><%= @event&.event || "—" %></dd>
+        </div>
+        <div class="grid grid-cols-3 gap-3">
+          <dt class="text-slate-500">距離</dt>
+          <dd class="col-span-2 text-slate-800"><%= @event&.distance ? "#{@event.distance} km" : "—" %></dd>
+        </div>
+      </dl>
+    </section>
 
-  <p>
-    <strong>日付:</strong>
-    <%= @race.date %>
-  </p>
+    <!-- 結果フォーム -->
+    <section class="lg:col-span-2">
+      <%= render "form", race_result: @race_result, race: @race %>
+    </section>
+  </div>
 
-  <p>
-    <strong>入金期限:</strong>
-    <%= @race.payment_due_date %>
-  </p>
-
-  <p>
-    <strong>種目:</strong>
-    <%= @event.event %>
-  </p>
-
-  <p>
-    <strong>距離:</strong>
-    <%= @event.distance %>km
-  </p>
-
-<%= render "form", form: @form %>
-
-<%= link_to '戻る', races_path %>
+  <div class="mt-6">
+    <%= link_to "戻る", races_path, class: "text-slate-600 hover:text-blue-700 underline underline-offset-4" %>
+  </div>
+</div>

--- a/app/views/race_results/show.html.erb
+++ b/app/views/race_results/show.html.erb
@@ -1,54 +1,82 @@
-<h1>試合結果の確認</h1>
+<!-- app/views/race_results/show.html.erb -->
+<div class="mx-auto max-w-5xl px-4 py-8">
+  <h1 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">試合結果の確認</h1>
 
-<div>
-  <p>
-    <strong>大会名:</strong>
-    <%= @race.name %>
-  </p>
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+    <!-- 大会サマリー -->
+    <section class="lg:col-span-1 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 class="text-lg font-semibold text-slate-900 mb-4"><%= @race.name %></h2>
+      <dl class="space-y-2 text-sm">
+        <div class="grid grid-cols-3 gap-3">
+          <dt class="text-slate-500">日付</dt>
+          <dd class="col-span-2 text-slate-800"><%= @race.date&.strftime("%Y/%m/%d") || "—" %></dd>
+        </div>
+        <div class="grid grid-cols-3 gap-3">
+          <dt class="text-slate-500">入金期限</dt>
+          <dd class="col-span-2 text-slate-800"><%= @race.payment_due_date&.strftime("%Y/%m/%d") || "—" %></dd>
+        </div>
+        <div class="grid grid-cols-3 gap-3">
+          <dt class="text-slate-500">種目</dt>
+          <dd class="col-span-2 text-slate-800"><%= @race.event&.event || "—" %></dd>
+        </div>
+        <div class="grid grid-cols-3 gap-3">
+          <dt class="text-slate-500">距離</dt>
+          <dd class="col-span-2 text-slate-800"><%= @race.event&.distance ? "#{@race.event.distance} km" : "—" %></dd>
+        </div>
+      </dl>
+      <div class="mt-4 space-y-1 text-sm">
+        <p><span class="text-slate-500">タイム：</span>
+          <span class="font-semibold text-slate-900"><%= @race_result.formatted_time_japanese %></span>
+        </p>
+        <p><span class="text-slate-500">感想：</span>
+          <span class="text-slate-800 whitespace-pre-line"><%= @race_result.impression.presence || "—" %></span>
+        </p>
+      </div>
+    </section>
 
-  <p>
-    <strong>日付:</strong>
-    <%= @race.date %>
-  </p>
+    <!-- コメント一覧 & 投稿 -->
+    <section class="lg:col-span-2 space-y-6">
+      <!-- コメント一覧 -->
+      <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <div class="flex items-center justify-between mb-4">
+          <h2 class="text-lg font-semibold text-slate-900">コメント</h2>
+          <span class="text-sm text-slate-600">件数：<%= @race_result.race_result_comments.count %></span>
+        </div>
 
-  <p>
-    <strong>入金期限:</strong>
-    <%= @race.payment_due_date %>
-  </p>
+        <% if @race_result.race_result_comments.any? %>
+          <ul class="space-y-4">
+            <% @race_result.race_result_comments.order(created_at: :desc).each do |c| %>
+              <li class="rounded-lg border border-slate-200 p-4">
+                <div class="flex items-center justify-between text-xs text-slate-500">
+                  <span><%= c.user&.name || "匿名" %></span>
+                  <time><%= c.created_at.strftime("%Y/%m/%d %H:%M") %></time>
+                </div>
+                <p class="mt-2 text-slate-800 whitespace-pre-line"><%= c.content %></p>
+              </li>
+            <% end %>
+          </ul>
+        <% else %>
+          <p class="text-sm text-slate-600">まだコメントはありません。最初のコメントを投稿しましょう！</p>
+        <% end %>
+      </div>
 
-  <p>
-    <strong>種目:</strong>
-    <%= @race.event.event %>
-  </p>
+      <!-- コメント投稿フォーム -->
+      <div class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+        <h3 class="text-base font-semibold text-slate-900 mb-3">コメントを投稿</h3>
+        <%= form_with model: [@race_result, @race_result_comment], local: true, class: "space-y-3" do |f| %>
+          <%= f.text_area :content, rows: 4,
+                placeholder: "レースの感想やメモをどうぞ",
+                class: "w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring focus:ring-blue-200" %>
+          <%= f.submit "送信する",
+                class: "inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-white text-sm font-semibold shadow hover:bg-blue-700 transition" %>
+        <% end %>
+      </div>
+    </section>
+  </div>
 
-  <p>
-    <strong>距離:</strong>
-    <%= @race.event.distance %>km
-  </p>
-
-  <p>
-    <strong>タイム:</strong>
-     <%= @race_result.formatted_time_japanese %>
-  </p>
-
-  <p>
-    <strong>感想:</strong>
-    <%= @race_result.impression %>
-  </p>
-
-<div>
-  <p>コメント件数：<%= @race_result.race_result_comments.count %></p>
-  <% @race_result.race_result_comments.each do |race_result_comment| %>
-    <%= race_result_comment.created_at.strftime('%Y/%m/%d') %>
-    <%= race_result_comment.content %>
-    <p><%= race_result_comment.user.name %></P>
-  <% end %>
+  <div class="mt-6">
+    <%= link_to "戻る", home_index_path,
+          class: "text-slate-600 hover:text-blue-700 underline underline-offset-4" %>
+  </div>
 </div>
 
-<div>
-  <%= form_with model: [@race_result, @race_result_comment] do |f| %>
-    <%= f.text_area :content, rows: '5', placeholder: "コメントをここに" %>
-    <%= f.submit "送信する" %>
-  <% end %>
-</div>
-<%= link_to '戻る', home_index_path %>

--- a/app/views/races/_footer.html.erb
+++ b/app/views/races/_footer.html.erb
@@ -1,3 +1,15 @@
-<%= link_to '編集', edit_race_path, class: 'btn btn-primary mr-3' %>
-<%= button_to '削除', race_path(@race), method: :delete, data: { confirm: '本当に削除しますか？' } %>
-<%= link_to '戻る', home_index_path %>
+<div class="flex flex-wrap gap-3 mt-6">
+  <!-- 編集 -->
+  <%= link_to '編集', edit_race_path(@race),
+      class: "inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-white text-sm font-semibold shadow hover:bg-blue-700 transition" %>
+
+  <!-- 削除 -->
+  <%= button_to '削除', race_path(@race),
+      method: :delete,
+      data: { confirm: '本当に削除しますか？' },
+      class: "inline-flex items-center rounded-lg bg-red-600 px-4 py-2 text-white text-sm font-semibold shadow hover:bg-red-700 transition" %>
+
+  <!-- 戻る -->
+  <%= link_to '戻る', home_index_path,
+      class: "inline-flex items-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:border-blue-300 hover:shadow-sm transition" %>
+</div>

--- a/app/views/races/_form.html.erb
+++ b/app/views/races/_form.html.erb
@@ -1,13 +1,44 @@
-<%= form_with model: @form ,scope: :race, local: true do |form| %>
-  <%= form.label '大会名'%>
-  <%= form.text_field :name,placeholder: '東京マラソン'  %>
-  <%= form.label '日程' %>
-  <%= form.text_area :date, placeholder: '2025-01-01' %>
-  <%= form.label '種目' %>
-  <%= form.text_field :event, placeholder: 'フルマラソン'  %>
-  <%= form.label '距離' %>
-  <%= form.text_field :distance, placeholder: '42.195' %>km
-  <%= form.label '入金期限' %>
-  <%= form.text_area :payment_due_date, placeholder: '2025-01-01' %>
-  <%= form.submit '登録' %>
+<%= form_with model: @form, scope: :race, local: true, class: "mx-auto max-w-lg space-y-6 bg-white p-6 rounded-xl shadow-sm border border-slate-200" do |f| %>
+  <!-- 大会名 -->
+  <div>
+    <%= f.label :name, "大会名", class: "block text-sm font-medium text-slate-700 mb-1" %>
+    <%= f.text_field :name, placeholder: "東京マラソン",
+      class: "w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring focus:ring-blue-200" %>
+  </div>
+
+  <!-- 日程（HTML5 date） -->
+  <div>
+    <%= f.label :date, "日程", class: "block text-sm font-medium text-slate-700 mb-1" %>
+    <%= f.date_field :date,
+      class: "w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring focus:ring-blue-200" %>
+  </div>
+
+  <!-- 種目 -->
+  <div>
+    <%= f.label :event, "種目", class: "block text-sm font-medium text-slate-700 mb-1" %>
+    <%= f.text_field :event, placeholder: "フルマラソン",
+      class: "w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring focus:ring-blue-200" %>
+  </div>
+
+  <!-- 距離（number + step） -->
+  <div>
+    <%= f.label :distance, "距離 (km)", class: "block text-sm font-medium text-slate-700 mb-1" %>
+    <div class="relative">
+      <%= f.number_field :distance, step: "0.001", min: "0", placeholder: "42.195",
+        class: "w-full rounded-lg border-slate-300 pr-14 focus:border-blue-500 focus:ring focus:ring-blue-200" %>
+      <span class="pointer-events-none absolute inset-y-0 right-3 flex items-center text-slate-500 text-sm">km</span>
+    </div>
+  </div>
+
+  <!-- 入金期限（HTML5 date） -->
+  <div>
+    <%= f.label :payment_due_date, "入金期限", class: "block text-sm font-medium text-slate-700 mb-1" %>
+    <%= f.date_field :payment_due_date,
+      class: "w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring focus:ring-blue-200" %>
+  </div>
+
+  <!-- ボタン -->
+  <div class="pt-2">
+    <%= f.submit "登録", class: "w-full rounded-lg bg-blue-600 px-4 py-2 text-white font-semibold shadow hover:bg-blue-700 transition" %>
+  </div>
 <% end %>

--- a/app/views/races/discover.html.erb
+++ b/app/views/races/discover.html.erb
@@ -1,17 +1,49 @@
-<h1> みんなの大会予定 </h1>
+<div class="mx-auto max-w-5xl px-4 py-8">
+  <h1 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">みんなの大会予定</h1>
 
-<% @races.each do |race| %>
-  <p>大会目：<%= race.name %></P>
-  <p>日付：<%= race.date %></P>
-  <p>投稿者：<%= race.user.name %>
-  <p>種目：<%= race.event.event %>
+  <% if @races.blank? %>
+    <div class="rounded-xl border border-slate-200 bg-white p-6 text-slate-600">
+      まだ大会予定がありません。
+    </div>
+  <% else %>
+    <ul class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <% @races.each do |race| %>
+        <li class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md transition">
+          <!-- 大会名 -->
+          <h2 class="text-lg font-semibold text-slate-900 mb-2"><%= race.name %></h2>
 
-<% if race.race_result.present? %>
-<p><%= link_to '結果を見る', race_race_result_path(race) %></P>
- <% else %>
-  <%= link_to '結果登録前', class: 'btn btn-primary mr-3' %>
- <% end %>
+          <!-- 詳細情報 -->
+          <div class="space-y-1 text-sm text-slate-700">
+            <p><span class="font-medium text-slate-500">日付：</span>
+              <%= race.date&.strftime("%Y/%m/%d") %>
+            </p>
+            <p><span class="font-medium text-slate-500">投稿者：</span>
+              <%= race.user.name %>
+            </p>
+            <p><span class="font-medium text-slate-500">種目：</span>
+              <%= race.event.event %>
+            </p>
+          </div>
 
- <% end %>
+          <!-- 結果リンク / 状態 -->
+          <div class="mt-4">
+            <% if race.race_result.present? %>
+              <%= link_to '結果を見る', race_race_result_path(race),
+                  class: "inline-flex items-center rounded-lg bg-emerald-600 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-700 transition" %>
+            <% else %>
+              <span class="inline-flex items-center rounded-lg bg-slate-100 px-3 py-2 text-sm font-semibold text-slate-500">
+                結果登録前
+              </span>
+            <% end %>
+          </div>
+        </li>
+      <% end %>
+    </ul>
+  <% end %>
 
-<p><%= link_to '戻る', home_index_path %></P>
+  <!-- 戻るボタン -->
+  <div class="mt-8">
+    <%= link_to '戻る', home_index_path,
+        class: "text-slate-600 hover:text-blue-700 underline underline-offset-4" %>
+  </div>
+</div>

--- a/app/views/races/edit.html.erb
+++ b/app/views/races/edit.html.erb
@@ -1,5 +1,12 @@
-<h1>大会予定の編集</h1>
+<div class="max-w-lg mx-auto mt-8 bg-white p-6 rounded-lg shadow">
+  <h1 class="text-2xl font-bold text-slate-800 mb-6 border-b pb-2">
+    大会予定の編集
+  </h1>
 
-<%= render "form", form: @form %>
+  <%= render "form", form: @form %>
 
-<%= link_to '戻る', home_index_path %>
+  <div class="mt-4">
+    <%= link_to '戻る', home_index_path,
+          class: "inline-block px-4 py-2 bg-gray-200 text-slate-800 rounded hover:bg-gray-300" %>
+  </div>
+</div>

--- a/app/views/races/index.html.erb
+++ b/app/views/races/index.html.erb
@@ -1,26 +1,68 @@
-<h1>大会予定</h1>
+<!-- app/views/races/index.html.erb -->
 
-<ul>
-  <% @races.each do |race| %>
-    <li>
-       <p><strong>大会名:</strong> <%= link_to race.name %></p>
-       <p><strong>日付:</strong> <%= race.date %></p>
-       <p><strong>入金期限:</strong> <%= race.payment_due_date %></p>
+<div class="mx-auto max-w-5xl px-4 py-8">
+  <h1 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">大会予定</h1>
 
-       <% if race.event.present? %>
-       <p><strong>種目:</strong> <%= race.event.event %></p>
-       <p><strong>距離:</strong> <%= race.event.distance %>km</p>
-     <% else %>
-       <p>イベント情報なし</p>
-     <% end %>
+  <% if @races.blank? %>
+    <div class="rounded-xl border border-slate-200 bg-white p-6 text-slate-600">
+      まだ大会が登録されていません。<%= link_to "大会を登録する", new_race_path, class: "text-blue-700 hover:underline" %>
+    </div>
+  <% else %>
+    <ul class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+      <% @races.each do |race| %>
+        <li class="rounded-xl border border-slate-200 bg-white p-5 shadow-sm hover:shadow-md transition">
+          <div class="flex items-start justify-between gap-3">
+            <h2 class="text-lg font-semibold text-slate-900">
+              <%= link_to race.name, race_path(race), class: "hover:text-blue-700" %>
+            </h2>
 
-      <%= link_to '詳細', race_path(race) %>
-      <% if race.race_result.present? %>
-      <%= link_to '結果を見る', race_race_result_path(race) %>
-       <% else %>
-        <%= link_to '結果を登録する', new_race_race_result_path(race), class: 'btn btn-primary mr-3' %>
-       <% end %>
-    </li>
+            <% if race.race_result.present? %>
+              <span class="inline-flex items-center rounded-full bg-emerald-50 px-2.5 py-1 text-xs font-medium text-emerald-700">
+                結果あり
+              </span>
+            <% else %>
+              <span class="inline-flex items-center rounded-full bg-slate-100 px-2.5 py-1 text-xs font-medium text-slate-600">
+                結果未登録
+              </span>
+            <% end %>
+          </div>
+
+          <div class="mt-3 space-y-1 text-sm text-slate-700">
+            <p><span class="font-medium text-slate-500">日付：</span>
+              <%= race.date&.strftime("%Y/%m/%d") %>
+            </p>
+            <p><span class="font-medium text-slate-500">入金期限：</span>
+              <%= race.payment_due_date&.strftime("%Y/%m/%d") || "—" %>
+            </p>
+
+            <% if race.event.present? %>
+              <p><span class="font-medium text-slate-500">種目：</span><%= race.event.event %></p>
+              <p><span class="font-medium text-slate-500">距離：</span><%= race.event.distance %> km</p>
+            <% else %>
+              <p class="text-slate-500">イベント情報なし</p>
+            <% end %>
+          </div>
+
+          <div class="mt-4 flex flex-wrap gap-2">
+            <%= link_to "詳細", race_path(race),
+                class: "inline-flex items-center rounded-lg bg-blue-600 px-3 py-2 text-sm font-semibold text-white hover:bg-blue-700 transition" %>
+
+            <% if race.race_result.present? %>
+              <%= link_to "結果を見る", race_race_result_path(race),
+                  class: "inline-flex items-center rounded-lg bg-emerald-600 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-700 transition" %>
+            <% else %>
+              <%= link_to "結果を登録する", new_race_race_result_path(race),
+                  class: "inline-flex items-center rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-800 hover:border-blue-300 hover:shadow-sm transition" %>
+            <% end %>
+          </div>
+        </li>
+      <% end %>
+    </ul>
   <% end %>
-</ul>
-<%= link_to '戻る', home_index_path %>
+
+  <div class="mt-8">
+    <%= link_to '戻る', home_index_path,
+        class: "text-slate-600 hover:text-blue-700 underline underline-offset-4" %>
+  </div>
+</div>
+

--- a/app/views/races/new.html.erb
+++ b/app/views/races/new.html.erb
@@ -1,5 +1,13 @@
-<h1>試合予定の登録</h1>
+<div class="max-w-lg mx-auto mt-8 bg-white p-6 rounded-lg shadow">
+  <h1 class="text-2xl font-bold text-slate-800 mb-6 border-b pb-2">
+    試合予定の登録
+  </h1>
 
-<%= render "form", form: @form %>
+  <%= render "form", form: @form %>
 
-<%= link_to '戻る', home_index_path %>
+  <div class="mt-4">
+    <%= link_to '戻る', home_index_path,
+          class: "inline-block px-4 py-2 bg-gray-200 text-slate-800 rounded hover:bg-gray-300" %>
+  </div>
+</div>
+

--- a/app/views/races/select_items.html.erb
+++ b/app/views/races/select_items.html.erb
@@ -1,11 +1,25 @@
-<%= form_with url: add_items_race_path(@race), method: :patch, local: true do %>
-  <h3>持っていくアイテムを選んでください</h3>
-  <% @items.each do |item| %>
-    <div>
-      <%= check_box_tag "race[item_ids][]", item.id, @race_item_ids.include?(item.id), id: "item_#{item.id}" %>
-      <%= label_tag "item_#{item.id}", item.name %>
-    </div>
-  <% end %>
+<%= form_with url: add_items_race_path(@race), method: :patch, local: true, class: "mx-auto max-w-lg space-y-6 bg-white p-6 rounded-xl shadow-sm border border-slate-200" do %>
+  <h3 class="text-lg font-semibold text-slate-900 mb-4">持っていくアイテムを選んでください</h3>
 
-  <%= submit_tag "追加する" %>
+  <div class="space-y-3">
+    <% @items.each do |item| %>
+      <div class="flex items-center gap-3 p-3 rounded-lg border border-slate-200 hover:bg-slate-50 transition">
+        <%= check_box_tag "race[item_ids][]", item.id, @race_item_ids.include?(item.id),
+              id: "item_#{item.id}",
+              class: "h-5 w-5 text-blue-600 border-slate-300 rounded focus:ring-blue-500" %>
+        <%= label_tag "item_#{item.id}", item.name, class: "text-slate-700 cursor-pointer" %>
+      </div>
+    <% end %>
+  </div>
+
+  <div class="pt-4">
+    <%= submit_tag "追加する",
+          class: "w-full rounded-lg bg-blue-600 px-4 py-2 text-white font-semibold shadow hover:bg-blue-700 transition" %>
+  </div>
+
+  <div class="mt-4">
+    <%= link_to '戻る', race_path,
+          class: "inline-block px-4 py-2 bg-gray-200 text-slate-800 rounded hover:bg-gray-300" %>
+  </div>
 <% end %>
+

--- a/app/views/races/show.html.erb
+++ b/app/views/races/show.html.erb
@@ -1,65 +1,97 @@
-<div>
-  <p>
-    <strong>大会名:</strong>
-    <%= @race.name %>
-  </p>
+<!-- app/views/races/show.html.erb -->
+<div class="mx-auto max-w-5xl px-4 py-8">
+  <h1 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6"><%= @race.name %></h1>
 
-  <p>
-    <strong>日付:</strong>
-    <%= @race.date %>
-  </p>
+  <div class="grid grid-cols-1 lg:grid-cols-3 gap-6">
+    <!-- 基本情報 -->
+    <section class="lg:col-span-2 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 class="text-lg font-semibold text-slate-900 mb-4">大会情報</h2>
+      <dl class="divide-y divide-slate-100">
+        <div class="py-3 grid grid-cols-3 gap-4">
+          <dt class="text-sm text-slate-500">日付</dt>
+          <dd class="col-span-2 text-sm text-slate-800"><%= @race.date&.strftime("%Y/%m/%d") || "—" %></dd>
+        </div>
+        <div class="py-3 grid grid-cols-3 gap-4">
+          <dt class="text-sm text-slate-500">入金期限</dt>
+          <dd class="col-span-2 text-sm text-slate-800"><%= @race.payment_due_date&.strftime("%Y/%m/%d") || "—" %></dd>
+        </div>
+        <div class="py-3 grid grid-cols-3 gap-4">
+          <dt class="text-sm text-slate-500">種目</dt>
+          <dd class="col-span-2 text-sm text-slate-800"><%= @event&.event || "—" %></dd>
+        </div>
+        <div class="py-3 grid grid-cols-3 gap-4">
+          <dt class="text-sm text-slate-500">距離</dt>
+          <dd class="col-span-2 text-sm text-slate-800"><%= @event&.distance ? "#{@event.distance} km" : "—" %></dd>
+        </div>
+      </dl>
+    </section>
 
-  <p>
-    <strong>入金期限:</strong>
-    <%= @race.payment_due_date %>
-  </p>
+    <!-- 宿泊情報 -->
+    <section class="rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+      <h2 class="text-lg font-semibold text-slate-900 mb-4">宿泊情報</h2>
+      <% sp = @stay_plan %>
+      <dl class="space-y-2 text-sm">
+        <div class="grid grid-cols-3 gap-4">
+          <dt class="text-slate-500">宿泊場所</dt>
+          <dd class="col-span-2 text-slate-800"><%= sp&.place_name || "未設定" %></dd>
+        </div>
+        <div class="grid grid-cols-3 gap-4">
+          <dt class="text-slate-500">住所</dt>
+          <dd class="col-span-2 text-slate-800"><%= sp&.address || "未設定" %></dd>
+        </div>
+        <div class="grid grid-cols-3 gap-4">
+          <dt class="text-slate-500">チェックイン</dt>
+          <dd class="col-span-2 text-slate-800"><%= sp&.check_in_time || "未設定" %></dd>
+        </div>
+        <div class="grid grid-cols-3 gap-4">
+          <dt class="text-slate-500">チェックアウト</dt>
+          <dd class="col-span-2 text-slate-800"><%= sp&.check_out_time || "未設定" %></dd>
+        </div>
+        <div class="grid grid-cols-3 gap-4">
+          <dt class="text-slate-500">備考</dt>
+          <dd class="col-span-2 text-slate-800 whitespace-pre-line"><%= sp&.note || "未設定" %></dd>
+        </div>
+      </dl>
+      <div class="mt-4">
+        <%= link_to '宿泊予定を登録', new_race_stay_plan_path(@race),
+            class: "inline-flex items-center rounded-lg border border-slate-300 bg-white px-3 py-2 text-sm font-semibold text-slate-800 hover:border-blue-300 hover:shadow-sm transition" %>
+      </div>
+    </section>
+  </div>
 
-  <p>
-    <strong>種目:</strong>
-    <%=  @event.event %>
-  </p>
+  <!-- 持ち物 -->
+  <section class="mt-6 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+    <h2 class="text-lg font-semibold text-slate-900 mb-4">持ち物リスト</h2>
+    <% if @race.items.any? %>
+      <ul class="flex flex-wrap gap-2">
+        <% @race.items.each do |item| %>
+          <li class="inline-flex items-center rounded-full bg-slate-100 px-3 py-1 text-sm text-slate-700">
+            <%= item.name %>
+          </li>
+        <% end %>
+      </ul>
+    <% else %>
+      <p class="text-sm text-slate-600">まだ登録されていません。</p>
+    <% end %>
+    <div class="mt-4">
+      <%= link_to '持ち物を追加', select_items_race_path(@race),
+          class: "inline-flex items-center rounded-lg bg-emerald-600 px-3 py-2 text-sm font-semibold text-white hover:bg-emerald-700 transition" %>
+    </div>
+  </section>
 
-  <p>
-    <strong>距離:</strong>
-    <%=  @event.distance %>km
-  </p>
+  <!-- アクションボタン -->
+  <div class="mt-6 flex flex-wrap gap-3">
+    <%= link_to '編集', edit_race_path(@race),
+        class: "inline-flex items-center rounded-lg bg-blue-600 px-4 py-2 text-white text-sm font-semibold shadow hover:bg-blue-700 transition" %>
 
-  <p>
-    <strong>宿泊場所:</strong>
-    <%= @stay_plan ? @stay_plan.place_name : "未設定" %>
-  </p>
+    <%= button_to '削除', race_path(@race),
+        method: :delete,
+        data: { confirm: '本当に削除しますか？' },
+        class: "inline-flex items-center rounded-lg bg-red-600 px-4 py-2 text-white text-sm font-semibold shadow hover:bg-red-700 transition" %>
+        <%= link_to '大会結果を登録', new_race_race_result_path(@race),
+        class: "inline-flex items-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:border-blue-300 hover:shadow-sm transition" %>
 
-  <p>
-  <strong>住所:</strong>
-  <%= @stay_plan ? @stay_plan.address : "未設定" %>
-  </p>
-
-  <p>
-  <strong>チェックイン:</strong>
-  <%= @stay_plan ? @stay_plan.check_in_time : "未設定" %>
-  </p>
-
-  <p>
-  <strong>チェックアウト:</strong>
-  <%= @stay_plan ? @stay_plan.check_out_time : "未設定" %>
-  </p>
-
-  <p>
-  <strong>備考:</strong>
-  <%= @stay_plan ? @stay_plan.note : "未設定" %>
-  </p>
-
-  <p>
-  <strong>持ち物リスト:</strong>
-  <% @race.items.each do |item| %>
-    <li><%= item.name %></li>
-  <% end %>
-  </p>
+          <%= link_to '戻る', home_index_path,
+        class: "inline-flex items-center rounded-lg border border-slate-300 bg-white px-4 py-2 text-sm font-semibold text-slate-800 hover:border-blue-300 hover:shadow-sm transition" %>
+  </div>
 </div>
-
-<%= link_to '編集', edit_race_path, class: 'btn btn-primary mr-3' %>
-<%= link_to '宿泊予定を登録', new_race_stay_plan_path(@race), class: 'btn btn-primary mr-3' %>
-<%= link_to '大会結果を登録', new_race_race_result_path(@race), class: 'btn btn-primary mr-3' %>
-<%= link_to '持ち物を追加' , select_items_race_path(@race),class: 'btn btn-primary mr-3' %>
-<%= button_to '削除', race_path(@race), method: :delete, data: { confirm: '本当に削除しますか？' } %>
-<%= link_to '戻る', home_index_path %>

--- a/app/views/stay_plans/new.html.erb
+++ b/app/views/stay_plans/new.html.erb
@@ -1,32 +1,57 @@
-<h1> 宿泊予定の登録 </h1>
+<div class="mx-auto max-w-lg px-4 py-8">
+  <h1 class="text-2xl md:text-3xl font-bold text-slate-900 mb-6">宿泊予定の登録</h1>
 
-<%= form_with(model: @stay_plan, url: race_stay_plan_path(params[:race_id]), local: true) do |form| %>
-<div>
-  <%= form.label '宿泊場所'  %>
-  <%= form.text_field :place_name %>
+  <%= form_with(model: @stay_plan, url: race_stay_plan_path(params[:race_id]), local: true,
+        class: "space-y-6 bg-white p-6 rounded-xl shadow-sm border border-slate-200") do |f| %>
+
+    <!-- 宿泊場所 -->
+    <div>
+      <%= f.label :place_name, "宿泊場所", class: "block text-sm font-medium text-slate-700 mb-1" %>
+      <%= f.text_field :place_name,
+            placeholder: "ホテル名や施設名",
+            class: "w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring focus:ring-blue-200" %>
+    </div>
+
+    <!-- 住所 -->
+    <div>
+      <%= f.label :address, "住所", class: "block text-sm font-medium text-slate-700 mb-1" %>
+      <%= f.text_field :address,
+            placeholder: "東京都〇〇区…",
+            class: "w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring focus:ring-blue-200" %>
+    </div>
+
+    <!-- チェックイン -->
+    <div>
+      <%= f.label :check_in_time, "チェックイン", class: "block text-sm font-medium text-slate-700 mb-1" %>
+      <%= f.time_field :check_in_time,
+            class: "w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring focus:ring-blue-200" %>
+    </div>
+
+    <!-- チェックアウト -->
+    <div>
+      <%= f.label :check_out_time, "チェックアウト", class: "block text-sm font-medium text-slate-700 mb-1" %>
+      <%= f.time_field :check_out_time,
+            class: "w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring focus:ring-blue-200" %>
+    </div>
+
+    <!-- 備考 -->
+    <div>
+      <%= f.label :note, "備考", class: "block text-sm font-medium text-slate-700 mb-1" %>
+      <%= f.text_area :note, rows: 3,
+            placeholder: "チェックインに関する注意や追加情報など",
+            class: "w-full rounded-lg border-slate-300 focus:border-blue-500 focus:ring focus:ring-blue-200" %>
+    </div>
+
+    <!-- 登録ボタン -->
+    <div>
+      <%= f.submit "登録",
+            class: "w-full rounded-lg bg-blue-600 px-4 py-2 text-white font-semibold shadow hover:bg-blue-700 transition" %>
+    </div>
+  <% end %>
+
+  <!-- 戻る -->
+  <div class="mt-6">
+    <%= link_to "戻る", :back,
+          class: "text-slate-600 hover:text-blue-700 underline underline-offset-4" %>
+  </div>
 </div>
-
-<div>
-  <%= form.label '住所'  %>
-  <%= form.text_field :address %>
-</div>
-
-<div>
-  <%= form.label 'チェックイン'  %>
-  <%= form.text_area :check_in_time %>
-</div>
-
-<div>
-  <%= form.label 'チェックアウト'  %>
-  <%= form.text_area :check_out_time %>
-</div>
-
-<div>
-  <%= form.label '備考'  %>
-  <%= form.text_field :note %>
-</div>
-
-  <%= form.submit %>
-<% end %>
-
-<%= link_to "戻る", :back %>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -1,8 +1,19 @@
-<head>プロフィール</head>
+<div class="max-w-md mx-auto mt-8 bg-white p-6 rounded-lg shadow">
+  <h1 class="text-2xl font-bold text-slate-800 mb-6 border-b pb-2">プロフィール</h1>
 
-<div>
-<p><strong>ユーザー名：</strong><%= @user.name %> </p>
-<p><strong>プロフィール：</strong><%= @user.profile %></p>
+  <div class="space-y-4">
+    <p>
+      <strong class="text-gray-600">ユーザー名：</strong>
+      <span class="text-slate-800"><%= @user.name %></span>
+    </p>
+    <p>
+      <strong class="text-gray-600">プロフィール：</strong>
+      <span class="text-slate-800"><%= @user.profile %></span>
+    </p>
+  </div>
+
+  <div class="mt-6">
+    <%= link_to '戻る', home_index_path,
+          class: "inline-block px-4 py-2 bg-gray-200 text-slate-800 rounded hover:bg-gray-300" %>
+  </div>
 </div>
-
-<%= link_to '戻る', home_index_path %>


### PR DESCRIPTION
## 変更の概要
ビューファイルにTailwindを使用しデザインを割り当て。

* 関連するIssue
https://github.com/Taunosuke/RunChronicle_2/issues/17
https://github.com/Taunosuke/RunChronicle_2/issues/16


## なぜこの変更をするのか
ユーザーの使用感向上のため

## やったこと

* [x] ChatGPTを使用しデザイン案のすり合わせ
* [x] 既存のViewファイルにChatGPTを使用してTailwindCSSのデザインを割り当て

## 変更内容

<img width="1158" height="690" alt="image" src="https://github.com/user-attachments/assets/24450fc0-300a-49b5-b616-42e30791e6bd" />

## 技術的な変更点
- TailwindCSS導入・設定
- 変更対象ファイル: ビューファイル全般
- レスポンシブ対応: モバイル・タブレット・デスクトップ

## 影響範囲

* ユーザーに影響すること
→アプリ画面のデザイン性向上によりアプリの使用感が上がっていること

* メンバーに影響すること
→個人開発のため他メンバーへの影響なし

* システムに影響すること
→UI変更のみのため内部処理に大きな変更なし

## どうやるのか
→使用方法は従来通り

## 課題
→本issueに関しては無し

## 備考

* その他に伝えたいこと