### PR TITLE
fix: メーラーのURL設定を修正してMissing host to link to エラーを解消

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -25,4 +25,8 @@ Rails.application.configure do
   if ENV["RENDER"] && ENV["RENDER_EXTERNAL_HOSTNAME"]
     config.hosts << ENV["RENDER_EXTERNAL_HOSTNAME"]
   end
+  config.action_mailer.default_url_options = { 
+  host: ENV["APP_HOST"] || "runchronicle.jp",
+  protocol: ENV["APP_PROTOCOL"] || "https"
+}
 end


### PR DESCRIPTION
関連issue
https://github.com/Taunosuke/RunChronicle_2/issues/39

